### PR TITLE
Bugfix I2C address

### DIFF
--- a/PCA9685.cpp
+++ b/PCA9685.cpp
@@ -87,8 +87,9 @@ void PCA9685::resetDevices() {
 void PCA9685::init(byte i2cAddress, byte mode) {
     if (_isProxyAddresser) return;
 
-    // I2C address is B 1 A5 A4 A3 A2 A1 A0 {W=0, R=1}
-    _i2cAddress = PCA9685_I2C_BASE_ADDRESS | ((i2cAddress & 0x3F) << 1);
+    // I2C 7-bit address is B 1 A5 A4 A3 A2 A1 A0
+    // RW bit added by Arduino core TWI library
+    _i2cAddress = PCA9685_I2C_BASE_ADDRESS | (i2cAddress & 0x3F);
 
 #ifdef PCA9685_ENABLE_DEBUG_OUTPUT
     Serial.print("PCA9685::init i2cAddress: 0x");

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,10 @@
 name=PCA9685 16-Channel PWM Driver Module Library
 version=1.2.8
-author=NachtRaveVL <nachtravevl@gmail.com>, Vitska, Kasper Skårhøj <kasperskaarhoj@gmail.com>
+author=NachtRaveVL <nachtravevl@gmail.com>, Vitska, Kasper SkÃ¥rhÃ¸j <kasperskaarhoj@gmail.com>
 maintainer=NachtRaveVL <nachtravevl@gmail.com>
 sentence=Library to control a PCA9685 16-channel PWM driver module from an Arduino board.
 paragraph=This library allows communication with boards running a PCA6985 16-channel PWM driver module. It supports a wide range of available functionality, from setting the output PWM frequecy, allowing multi-device proxy addressing, and provides an assistant class for working with Servos.
 category=Device Control
 url=https://github.com/NachtRaveVL/PCA9685-Arduino
 architectures=*
+ 


### PR DESCRIPTION
Arduino TWI library expects 7 bit addresses. The TWI library wrapped by the Wire library performs the address shift and adds the r/w bit to the address. See here https://github.com/esp8266/Arduino/blob/master/cores/esp8266/core_esp8266_si2c.c#L184
" if(!twi_write_byte(((address << 1) | 0) & 0xFF)) {"
and
"if(!twi_write_byte(((address << 1) | 1) & 0xFF)) {".

Confirmed with three chained PCA9685 boards connected a NodeMCU.